### PR TITLE
Implemented `quarter-hysteresis-loop` and renaming of partial hysteresis

### DIFF
--- a/hdr/program.hpp
+++ b/hdr/program.hpp
@@ -51,7 +51,8 @@ namespace program
 	extern void time_series();
 	extern int hysteresis();
 	extern int static_hysteresis();
-   extern void partial_hysteresis_loop();
+   extern void half_hysteresis_loop();
+   extern void quarter_hysteresis_loop();
 	extern int curie_temperature();
 	extern void field_cool();
 	extern void local_field_cool();

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -103,8 +103,8 @@ void output(){ // should include variables for data to be outputted, eg spins, c
          // If using GPU acceleration then synchonise spins from device
          gpu::config::synchronise();
 
-         // for all programs except hysteresis(=2), static-hysteresis(=3) and partial-hysteresis(=12)
-         if ((program::program != 2) && (program::program != 3) && (program::program != 12))
+         // for all programs except hysteresis(=2), static-hysteresis(=3), half-hysteresis(=12), quarter-hysteresis(=74)
+         if ((program::program != 2) && (program::program != 3) && (program::program != 12) && (program::program != 74))
          {
 
             //Always output coordinates the first time (re-)started, otherwise the spins coordinates won't be printed
@@ -117,7 +117,7 @@ void output(){ // should include variables for data to be outputted, eg spins, c
             config::internal::output_rate_counter_coords++; //update the counter
          }
          // for hysteresis programs
-         else if ((program::program == 2) || (program::program ==3) || (program::program ==12))
+         else if ((program::program == 2) || (program::program ==3) || (program::program ==12) || (program::program ==74))
          {
             // output config only in range [minField_1;maxField_1] for descending branch
             if (sim::parity < 0)
@@ -163,14 +163,14 @@ void output(){ // should include variables for data to be outputted, eg spins, c
       // Otherwise print cells configurations during simulation
       else if (config::internal::output_cells_config_continuous  && (sim::output_rate_counter % config::internal::output_cells_config_rate == 0))
       {
-         // for all programs except hysteresis(=2), static-hysteresis(=3) and partial-hysteresis(=12)
-         if ((program::program != 2) && (program::program != 3) && (program::program != 12))
+         // for all programs except hysteresis(=2), static-hysteresis(=3), half-hysteresis(=12) and quarter-hysteresis(=74)
+         if ((program::program != 2) && (program::program != 3) && (program::program != 12) && (program::program != 74))
          {
             if (sim::output_cells_file_counter == 0) config::internal::legacy_cells_coords();
             config::internal::legacy_cells();
          }
          // for hysteresis programs
-         else if ((program::program == 2) || (program::program ==3) || (program::program ==12))
+         else if ((program::program == 2) || (program::program ==3) || (program::program ==12) || (program::program ==74))
          {
             // output config only in range [minField_1;maxField_1] for decreasing field
             if (sim::parity < 0)

--- a/src/program/half_hysteresis.cpp
+++ b/src/program/half_hysteresis.cpp
@@ -23,12 +23,12 @@
 
 namespace program{
 
-/// @brief Function to calculate the partial hysteresis loop
+/// @brief Function to calculate a half hysteresis loop
 ///
 /// @callgraph
 /// @callergraph
 ///
-/// @details sim:program=partial-hysteresis-loop simulates a partial hysteresis loop, starting at
+/// @details sim:program=half-hysteresis-loop simulates a half hysteresis loop, starting at
 ///          sim:minimum-applied-field-strength to sim:maximum-applied-field-strength in steps of
 ///          sim:applied-field-strength-increment. Note that the sign of the increment is
 ///          significant, indicating the direction of the loop. Invalid combinations (which lead to
@@ -52,10 +52,10 @@ namespace program{
 ///	Revision:	  ---
 ///=====================================================================================
 ///
-void partial_hysteresis_loop(){
+void half_hysteresis_loop(){
 
    // check calling of routine if error checking is activated
-   if(err::check==true){std::cout << "program::partial-hysteresis has been called" << std::endl;}
+   if(err::check==true){std::cout << "program::half-hysteresis has been called" << std::endl;}
 
    // Equilibrate system in saturation field
    sim::H_applied=sim::Heq;

--- a/src/program/interface.cpp
+++ b/src/program/interface.cpp
@@ -100,7 +100,7 @@ namespace program{
             program::program=11;
             return true;
          }
-         test="partial-hysteresis-loop";
+         test="half-hysteresis-loop";
          if(value==test){
             program::program=12;
             return true;
@@ -165,6 +165,11 @@ namespace program{
             program::program=73;
             return true;
          }
+         test="quarter-hysteresis-loop";
+         if(value==test){
+            program::program=74;
+            return true;
+         }
          else{
             terminaltextcolor(RED);
             std::cout << word << '\t' << test << std::endl;
@@ -182,10 +187,11 @@ namespace program{
             std::cerr << "\t\"localised-temperature-pulse\"" << std::endl;
             std::cerr << "\t\"time-series\"" << std::endl;
             std::cerr << "\t\"hysteresis-loop\"" << std::endl;
-            std::cerr << "\t\"partial-hysteresis-loop\"" << std::endl;
+            std::cerr << "\t\"half-hysteresis-loop\"" << std::endl;
             std::cerr << "\t\"hybrid-cmc\"" << std::endl;
             std::cerr << "\t\"reverse-hybrid-cmc\"" << std::endl;
             std::cerr << "\t\"static-hysteresis-loop\"" << std::endl;
+            std::cerr << "\t\"quarter-hysteresis-loop\"" << std::endl;
             terminaltextcolor(WHITE);
             err::vexit();
          }

--- a/src/program/makefile
+++ b/src/program/makefile
@@ -27,11 +27,12 @@ interface.o \
 lagrange.o \
 LLB_Boltzmann.o \
 micromagnetic_A_calculation.o \
-partial_hysteresis.o \
+half_hysteresis.o \
 static_hysteresis.o \
 setting.o \
 time_series.o \
-temperature_pulse.o
+temperature_pulse.o \
+quarter_hysteresis.o
 
 # Append module objects to global tree
 OBJECTS+=$(addprefix obj/program/,$(program_objects))

--- a/src/program/quarter_hysteresis.cpp
+++ b/src/program/quarter_hysteresis.cpp
@@ -1,0 +1,101 @@
+//------------------------------------------------------------------------------
+//
+//   This file is part of the VAMPIRE open source package under the
+//   Free BSD licence (see licence file for details).
+//
+//   (c) Andrea Meo and Richard Evans 2019. All rights reserved.
+//
+//   Email: richard.evans@york.ac.uk
+//
+//------------------------------------------------------------------------------
+//
+
+// Standard Libraries
+#include <cstdlib>
+
+// Vampire Header files
+#include "vmath.hpp"
+#include "errors.hpp"
+#include "sim.hpp"
+#include "stats.hpp"
+#include "vio.hpp"
+
+
+namespace program{
+
+/// @brief Function to calculate the quarter hysteresis loop
+///
+/// @callgraph
+/// @callergraph
+///
+///
+/// @section License
+/// Use of this code, either in source or compiled form, is subject to license from the authors.
+/// Copyright \htmlonly &copy \endhtmlonly Richard Evans, 2009-2010. All Rights Reserved.
+///
+/// @section Information
+/// @author  Richard Evans, richard.evans@york.ac.uk
+/// @version 1.0
+///
+/// @return EXIT_SUCCESS
+///
+/// @internal
+///	Revision:	  ---
+///=====================================================================================
+///
+void quarter_hysteresis_loop(){
+
+   // check calling of routine if error checking is activated
+   if(err::check==true){std::cout << "program::quarter-hysteresis has been called" << std::endl;}
+
+   // Equilibrate system in saturation field
+   sim::H_applied=sim::Heq;
+   sim::integrate(sim::equilibration_time);
+
+   // Setup min and max fields and increment (uT)
+   int64_t iHmax=vmath::iround64(double(sim::Hmax)*1.0E6);
+   int64_t iHmin=vmath::iround64(double(0.0));
+   int64_t iHinc=vmath::iround64(double(sim::Hinc)*1.0E6);
+
+   // Check for loop direction and adjust parameters
+   // so that field loop works in positive sense
+   double parity=1.0;
+   if(iHinc < 0){
+      iHmax=-iHmax;
+      iHmin=-iHmin;
+      iHinc=-iHinc;
+      parity=-1.0;
+   }
+
+   // Perform Field Loop
+   for(int H=iHmax;H>=0.0;H-=iHinc){
+
+      // Set applied field (Tesla)
+      sim::H_applied=double(H)*parity*1.0e-6;
+
+      // Reset start time
+      uint64_t start_time=sim::time;
+
+      // Reset mean magnetisation counters
+      stats::reset();
+
+      // Integrate system
+      while(sim::time<sim::loop_time+start_time){
+
+         // Integrate system
+         sim::integrate(sim::partial_time);
+
+         // Calculate mag_m, mag
+         stats::update();
+
+      }
+
+      // Output to screen and file after each field
+      vout::data();
+
+   } // End of field loop
+
+   return;
+}
+
+}//end of namespace program

--- a/src/program/quarter_hysteresis.cpp
+++ b/src/program/quarter_hysteresis.cpp
@@ -57,21 +57,11 @@ void quarter_hysteresis_loop(){
    int64_t iHmin=vmath::iround64(double(0.0));
    int64_t iHinc=vmath::iround64(double(sim::Hinc)*1.0E6);
 
-   // Check for loop direction and adjust parameters
-   // so that field loop works in positive sense
-   double parity=1.0;
-   if(iHinc < 0){
-      iHmax=-iHmax;
-      iHmin=-iHmin;
-      iHinc=-iHinc;
-      parity=-1.0;
-   }
-
    // Perform Field Loop
-   for(int H=iHmax;H>=0.0;H-=iHinc){
+   for(int H=iHmax;H>=iHmin;H-=iHinc){
 
       // Set applied field (Tesla)
-      sim::H_applied=double(H)*parity*1.0e-6;
+      sim::H_applied=double(H)*1.0e-6;
 
       // Reset start time
       uint64_t start_time=sim::time;

--- a/src/simulate/sim.cpp
+++ b/src/simulate/sim.cpp
@@ -426,10 +426,10 @@ int run(){
 
       case 12:
          if(vmpi::my_rank==0){
-            std::cout << "partial-hysteresis-loop..." << std::endl;
-            zlog << "partial-hysteresis-loop..." << std::endl;
+            std::cout << "half-hysteresis-loop..." << std::endl;
+            zlog << "half-hysteresis-loop..." << std::endl;
          }
-         program::partial_hysteresis_loop();
+         program::half_hysteresis_loop();
          break;
 
       case 13:
@@ -534,6 +534,15 @@ int run(){
 			}
 			program::boltzmann_dist_micromagnetic_llg();
 			break;
+		//------------------------------------------------------------------------
+		case 74:
+		 	if(vmpi::my_rank==0){
+				std::cout << "quarter-hysteresis-loop..." << std::endl;
+				zlog << "quarter-hysteresis-loop..." << std::endl;
+			}
+			program::quarter_hysteresis_loop();
+			break;
+		//------------------------------------------------------------------------
 		default:{
 			std::cerr << "Unknown Internal Program ID "<< program::program << " requested, exiting" << std::endl;
 			zlog << "Unknown Internal Program ID "<< program::program << " requested, exiting" << std::endl;


### PR DESCRIPTION
Changes:
- [x] Added quarter hysteresis loops, where the field goes from $H_\text{max}$ to 0
- [x] Renamed internal variables related to "partial hysteresis loops" to "half hysteresis loops" 

Notes:
- The quarter hysteresis loop program can be invoked with `program:quarter-hysteresis-loop` while the formerly known partial hysteresis loop program is now invoked with `program:half-hysteresis-loop`.